### PR TITLE
Gemini Plan to Setup Playwright extension fixture

### DIFF
--- a/apps/extension-e2e/package.json
+++ b/apps/extension-e2e/package.json
@@ -1,10 +1,5 @@
 {
   "name": "extension-e2e",
   "version": "0.0.1",
-  "private": true,
-  "nx": {
-    "implicitDependencies": [
-      "extension"
-    ]
-  }
+  "private": true
 }

--- a/apps/extension-e2e/project.json
+++ b/apps/extension-e2e/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "extension-e2e",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/extension-e2e/src",
+  "projectType": "application",
+  "targets": {
+    "e2e": {
+      "executor": "@nx/playwright:playwright",
+      "outputs": ["{workspaceRoot}/dist/.playwright/apps/extension-e2e"],
+      "options": {
+        "config": "apps/extension-e2e/playwright.config.ts"
+      },
+      "dependsOn": [
+        {
+          "target": "build",
+          "project": "extension"
+        }
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/apps/extension-e2e/src/example.spec.ts
+++ b/apps/extension-e2e/src/example.spec.ts
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-// WXT is not yet set up for E2E testing so this is just a test scaffold
-test('basic test', async ({ page }) => {
-  await page.goto('https://example.com');
-  expect(await page.title()).toContain('Example');
-});

--- a/apps/extension-e2e/src/popup.spec.ts
+++ b/apps/extension-e2e/src/popup.spec.ts
@@ -8,7 +8,7 @@ test('Popup page should load and render correctly', async ({
 
   await expect(page.getByText('Hello popup!')).toBeVisible();
   await expect(page.getByText('Hello extension component!')).toBeVisible();
-  await expect(page.getByText('Hello from shared lib!')).toBeVisible();
+  await expect(page.getByText('Hello shared component!')).toBeVisible();
   await expect(
     page.getByRole('button', { name: 'Toggle Sidepanel' }),
   ).toBeVisible();

--- a/apps/extension-e2e/src/popup.spec.ts
+++ b/apps/extension-e2e/src/popup.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from './wxt-fixture';
+
+test('Popup page should load and render correctly', async ({
+  page,
+  extensionId,
+}) => {
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  await expect(page.getByText('Hello popup!')).toBeVisible();
+  await expect(page.getByText('Hello extension component!')).toBeVisible();
+  await expect(page.getByText('Hello from shared lib!')).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Toggle Sidepanel' }),
+  ).toBeVisible();
+});

--- a/apps/extension-e2e/src/wxt-fixture.ts
+++ b/apps/extension-e2e/src/wxt-fixture.ts
@@ -1,17 +1,24 @@
 import { test as base, chromium, type BrowserContext } from '@playwright/test';
 import path from 'path';
+import fs from 'fs/promises';
+import os from 'os';
 
 const extensionPath = path.join(
   __dirname,
   '../../../apps/extension/.output/chrome-mv3',
 );
 
+let userDataDir: string;
+
 export const test = base.extend<{
   context: BrowserContext;
   extensionId: string;
 }>({
-  context: async ({}, use) => {
-    const context = await chromium.launchPersistentContext('', {
+  context: async (_, use) => {
+    userDataDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'chromium-user-data-'),
+    );
+    const context = await chromium.launchPersistentContext(userDataDir, {
       headless: process.env.CI ? true : false,
       args: [
         `--disable-extensions-except=${extensionPath}`,
@@ -20,15 +27,12 @@ export const test = base.extend<{
     });
     await use(context);
     await context.close();
+    await fs.rm(userDataDir, { recursive: true, force: true });
   },
-  extensionId: async ({ context }, use) => {
-    const serviceWorker =
-      context.serviceWorkers().length > 0
-        ? context.serviceWorkers()[0]
-        : await context.waitForEvent('serviceworker');
-
-    const extensionId = new URL(serviceWorker.url()).hostname;
-    await use(extensionId);
+  extensionId: async (_, use) => {
+    const extensionsDir = path.join(userDataDir, 'Default', 'Extensions');
+    const [id] = await fs.readdir(extensionsDir);
+    await use(id);
   },
 });
 

--- a/apps/extension-e2e/src/wxt-fixture.ts
+++ b/apps/extension-e2e/src/wxt-fixture.ts
@@ -1,0 +1,35 @@
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import path from 'path';
+
+const extensionPath = path.join(
+  __dirname,
+  '../../../apps/extension/.output/chrome-mv3',
+);
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      headless: process.env.CI ? true : false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    const serviceWorker =
+      context.serviceWorkers().length > 0
+        ? context.serviceWorkers()[0]
+        : await context.waitForEvent('serviceworker');
+
+    const extensionId = new URL(serviceWorker.url()).hostname;
+    await use(extensionId);
+  },
+});
+
+export const expect = test.expect;

--- a/apps/extension/src/entrypoints/sidepanel/main.tsx
+++ b/apps/extension/src/entrypoints/sidepanel/main.tsx
@@ -3,14 +3,15 @@ import * as ReactDOM from 'react-dom/client';
 import { toggleSidePanel } from '../../utils/sidepanel';
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById('root') as HTMLElement,
 );
 
 root.render(
   <StrictMode>
     <div className="flex flex-col gap-4 p-4">
-      <div>Hello popup!</div>
+      {/* Changed this text to be specific to the side panel */}
+      <div>Hello from the side panel!</div>
       <button onClick={toggleSidePanel}>Toggle Sidepanel</button>
     </div>
-  </StrictMode>
+  </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- create Nx project for extension E2E tests
- remove unused nx block from extension-e2e package.json
- create custom Playwright fixture and popup test
- update side panel entry text

## Testing
- `pnpm format:write`
- `pnpm validate` *(fails: unable to download Nx Cloud)*

------
https://chatgpt.com/codex/tasks/task_e_687c9e6842088331a9b5173fcaa8b876