### PR TITLE
o3 Plan for Setup working extension E2E test

### DIFF
--- a/apps/extension-e2e/playwright.config.ts
+++ b/apps/extension-e2e/playwright.config.ts
@@ -1,20 +1,12 @@
+import { nxE2EPreset } from '@nx/playwright/preset';
 import { defineConfig, devices } from '@playwright/test';
-
 export default defineConfig({
-  testDir: './src',
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  ...nxE2EPreset(__filename, { testDir: './src' }),
   use: { trace: 'on-first-retry' },
   projects: [
     {
       name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        channel: 'chromium',
-        headless: true,
-      },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
 });

--- a/apps/extension-e2e/playwright.config.ts
+++ b/apps/extension-e2e/playwright.config.ts
@@ -1,68 +1,20 @@
 import { defineConfig, devices } from '@playwright/test';
-import { nxE2EPreset } from '@nx/playwright/preset';
 
-// For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
-
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
-  ...nxE2EPreset(__filename, { testDir: './src' }),
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-  use: {
-    baseURL,
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-  },
-  /* Run your local dev server before starting the tests */
-  // TODO: Fix local web server when setting up WXT for E2E testing
-  // webServer: {
-  //   command: 'pnpm exec nx run extension:preview',
-  //   url: 'http://localhost:4200',
-  //   reuseExistingServer: true,
-  //   cwd: workspaceRoot,
-  // },
+  testDir: './src',
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: { trace: 'on-first-retry' },
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chromium',
+        headless: false,
+      },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    // Uncomment for mobile browsers support
-    /* {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    }, */
-
-    // Uncomment for branded browsers
-    /* {
-      name: 'Microsoft Edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
-    {
-      name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    } */
   ],
 });

--- a/apps/extension-e2e/playwright.config.ts
+++ b/apps/extension-e2e/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         channel: 'chromium',
-        headless: false,
+        headless: true,
       },
     },
   ],

--- a/apps/extension-e2e/project.json
+++ b/apps/extension-e2e/project.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "extension-e2e",
+  "projectType": "application",
+  "sourceRoot": "apps/extension-e2e/src",
+  "implicitDependencies": ["extension"],
+  "targets": {
+    "e2e": {
+      "executor": "@nx/playwright:playwright",
+      "dependsOn": [{ "target": "build", "projects": "dependencies" }],
+      "options": {
+        "config": "apps/extension-e2e/playwright.config.ts"
+      }
+    }
+  }
+}

--- a/apps/extension-e2e/src/example.spec.ts
+++ b/apps/extension-e2e/src/example.spec.ts
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-// WXT is not yet set up for E2E testing so this is just a test scaffold
-test('basic test', async ({ page }) => {
-  await page.goto('https://example.com');
-  expect(await page.title()).toContain('Example');
-});

--- a/apps/extension-e2e/src/fixtures.ts
+++ b/apps/extension-e2e/src/fixtures.ts
@@ -12,7 +12,8 @@ export const test = base.extend<{
   context: BrowserContext;
   extensionId: string;
 }>({
-  context: async (_, use) => {
+  // eslint-disable-next-line no-empty-pattern
+  context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
       channel: 'chromium',
       headless: true,
@@ -24,10 +25,13 @@ export const test = base.extend<{
     await use(context);
     await context.close();
   },
-
-  extensionId: async (_, use) => {
+  // eslint-disable-next-line no-empty-pattern
+  extensionId: async ({}, use) => {
     const realPath = realpathSync(pathToExtension);
-    const hex = createHash('sha256').update(realPath).digest('hex').slice(0, 32);
+    const hex = createHash('sha256')
+      .update(realPath)
+      .digest('hex')
+      .slice(0, 32);
     const alphabet = 'abcdefghijklmnop';
     const id = [...hex].map((c) => alphabet[parseInt(c, 16)]).join('');
     await use(id);

--- a/apps/extension-e2e/src/fixtures.ts
+++ b/apps/extension-e2e/src/fixtures.ts
@@ -1,0 +1,36 @@
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import { resolve } from 'path';
+
+const pathToExtension = resolve(
+  __dirname,
+  '../../extension/.output/chrome-mv3',
+);
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  context: async (_, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  extensionId: async ({ context }, use) => {
+    let [serviceWorker] = context.serviceWorkers();
+    if (!serviceWorker) {
+      serviceWorker = await context.waitForEvent('serviceworker');
+    }
+    const id = new URL(serviceWorker.url()).host;
+    await use(id);
+  },
+});
+
+export const expect = test.expect;

--- a/apps/extension-e2e/src/fixtures.ts
+++ b/apps/extension-e2e/src/fixtures.ts
@@ -1,7 +1,7 @@
 import { test as base, chromium, type BrowserContext } from '@playwright/test';
-import { resolve } from 'path';
 import { createHash } from 'crypto';
 import { realpathSync } from 'fs';
+import { resolve } from 'path';
 
 const pathToExtension = resolve(
   __dirname,

--- a/apps/extension-e2e/src/popup.spec.ts
+++ b/apps/extension-e2e/src/popup.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from './fixtures';
+
+test('popup renders shared components', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  await expect(page.getByText('Hello popup!')).toBeVisible();
+  await expect(page.getByText('Hello extension component!')).toBeVisible();
+  await expect(page.getByText('Hello shared')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- prebuild the extension for E2E
- load the built extension in a custom Playwright fixture
- update Playwright config for persistent Chromium context
- add a popup test exercising shared components

## Testing
- `pnpm check`
- `npx nx run-many --target=lint --skip-nx-cache`

------
https://chatgpt.com/codex/tasks/task_e_687c9dfac72c8331814b285f7ae224ff