### PR TITLE
Grok Plan for Setup Chrome extension e2e tests

### DIFF
--- a/apps/extension-e2e/playwright.config.ts
+++ b/apps/extension-e2e/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
 
-// For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+// No base URL is needed when testing extensions
+const baseURL = '';
 
 /**
  * Read environment variables from file.
@@ -20,30 +20,23 @@ export default defineConfig({
     baseURL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    headless: false,
   },
-  /* Run your local dev server before starting the tests */
-  // TODO: Fix local web server when setting up WXT for E2E testing
-  // webServer: {
-  //   command: 'pnpm exec nx run extension:preview',
-  //   url: 'http://localhost:4200',
-  //   reuseExistingServer: true,
-  //   cwd: workspaceRoot,
-  // },
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     // Uncomment for mobile browsers support
     /* {

--- a/apps/extension-e2e/src/example.spec.ts
+++ b/apps/extension-e2e/src/example.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
-// WXT is not yet set up for E2E testing so this is just a test scaffold
-test('basic test', async ({ page }) => {
-  await page.goto('https://example.com');
-  expect(await page.title()).toContain('Example');
+test('popup loads correctly', async ({ page, extensionId }) => {
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+  await expect(page.getByText('Hello popup!')).toBeVisible();
+  await expect(page.getByText('Hello extension component!')).toBeVisible();
+  await expect(page.getByText('Hello shared component!')).toBeVisible();
 });

--- a/apps/extension-e2e/src/fixtures.ts
+++ b/apps/extension-e2e/src/fixtures.ts
@@ -1,0 +1,37 @@
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import path from 'path';
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  context: async (_args, use) => {
+    const pathToExtension = path.join(
+      __dirname,
+      '..',
+      '..',
+      'extension',
+      '.output',
+      'chrome-mv3',
+    );
+    const context = await chromium.launchPersistentContext('', {
+      headless: true,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    const extensionId = background.url().split('/')[2];
+    await use(extensionId);
+  },
+});
+
+export const expect = test.expect;

--- a/nx.json
+++ b/nx.json
@@ -70,6 +70,9 @@
   "targetDefaults": {
     "test": {
       "dependsOn": ["^build"]
+    },
+    "e2e": {
+      "dependsOn": ["^build"]
     }
   },
   "generators": {


### PR DESCRIPTION
## Summary
- ensure e2e target depends on extension build
- adjust Playwright config for extension testing
- load the extension in a Playwright fixture
- check popup contents instead of navigating to an external site
- fix lint warning in Playwright fixture

## Testing
- `pnpm format:write`
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_687c9e399e888331b40e04607a5313ac